### PR TITLE
FrescoControllerListener is now supporting RN 0.64

### DIFF
--- a/android/src/main/java/iyegoroff/imagefilterkit/FrescoControllerListener.java
+++ b/android/src/main/java/iyegoroff/imagefilterkit/FrescoControllerListener.java
@@ -2,14 +2,14 @@ package iyegoroff.imagefilterkit;
 
 import android.graphics.drawable.Animatable;
 
-import com.facebook.drawee.controller.BaseControllerListener;
 import com.facebook.drawee.controller.ControllerListener;
 import com.facebook.imagepipeline.image.ImageInfo;
+import com.facebook.react.views.image.ReactImageDownloadListener;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class FrescoControllerListener extends BaseControllerListener<ImageInfo> {
+public class FrescoControllerListener extends ReactImageDownloadListener<ImageInfo> {
   private final @Nullable ControllerListener<ImageInfo> mWrappedListener;
   private final @Nonnull Functor.Arity0 mImageUpdated;
   private final @Nonnull Functor.Arity1<Throwable> mError;

--- a/android/src/main/java/iyegoroff/imagefilterkit/ReactImageViewUtils.java
+++ b/android/src/main/java/iyegoroff/imagefilterkit/ReactImageViewUtils.java
@@ -19,7 +19,7 @@ class ReactImageViewUtils {
   @Nullable
   static ControllerListener<ImageInfo> getControllerListener(@Nullable ReactImageView target) {
     return target != null
-      ? ReflectUtils.getFieldValue(target, "mControllerListener")
+      ? ReflectUtils.getFieldValue(target, "mDownloadListener")
       : null;
   }
 
@@ -28,7 +28,7 @@ class ReactImageViewUtils {
     @Nullable ControllerListener<ImageInfo> listener
   ) {
     if (target != null) {
-      ReflectUtils.setFieldValue(target, "mControllerListener", listener);
+      ReflectUtils.setFieldValue(target, "mDownloadListener", listener);
     }
   }
 


### PR DESCRIPTION
Hey.
So I had an issue on Android RN 0.64 that sometimes some of the cssgram filters (Xpro2) were not working by showing white images. After some debugging I found out that the structure of ```com.facebook.react.views.image.ReactImageView``` has changed.  I updated what needed to be updated and seems to be working for me now. 